### PR TITLE
fix(os): treat empty VITE_CDN_BASE as /cdn fallback

### DIFF
--- a/os/utils/cdn.ts
+++ b/os/utils/cdn.ts
@@ -15,10 +15,13 @@
  *   const url = `${REDBOOK_CDN}/avatars/foo.jpg`;
  */
 
-const CDN_BASE = (
-  (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env?.VITE_CDN_BASE
-  ?? '/cdn'
-).replace(/\/+$/, '');
+export function resolveCdnBase(raw: string | undefined): string {
+  return (raw?.trim() || '/cdn').replace(/\/+$/, '');
+}
+
+const CDN_BASE = resolveCdnBase(
+  (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env?.VITE_CDN_BASE,
+);
 
 export function cdn(subpath: string = ''): string {
   const cleaned = subpath.replace(/^\/+/, '').replace(/\/+$/, '');

--- a/tests/cdn.test.ts
+++ b/tests/cdn.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCdnBase } from '../os/utils/cdn';
+
+describe('resolveCdnBase', () => {
+  it('treats empty string as /cdn (Vite .env.local default)', () => {
+    expect(resolveCdnBase('')).toBe('/cdn');
+    expect(resolveCdnBase('   ')).toBe('/cdn');
+  });
+
+  it('preserves explicit remote base', () => {
+    expect(resolveCdnBase('https://cdn.mobilegym.dev')).toBe('https://cdn.mobilegym.dev');
+  });
+
+  it('falls back for undefined', () => {
+    expect(resolveCdnBase(undefined)).toBe('/cdn');
+  });
+
+  it('strips trailing slashes', () => {
+    expect(resolveCdnBase('/cdn/')).toBe('/cdn');
+    expect(resolveCdnBase('https://cdn.mobilegym.dev/')).toBe('https://cdn.mobilegym.dev');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix CDN base resolution when `VITE_CDN_BASE=` is left empty in `.env.local` (copied from `.env.example`).
- Vite injects an empty string, not `undefined`; `?? '/cdn'` never fired, so URLs became `/themes/...` instead of `/cdn/themes/...`.
- This broke launcher WMR widgets (manifest fetch returned HTML → `WMR: no <Clock>/<Widget> root element`) even when `mobilegym-data` was installed.

## Reproduction (before)

1. `cp .env.example .env.local` (default `VITE_CDN_BASE=`)
2. Install `mobilegym-data`, `npm run dev`
3. Open http://localhost:3000 — two red WMR error boxes on home screen
4. `curl http://localhost:3000/themes/.../manifest.xml` returns HTML, not XML

## Fix

Use `?.trim() || '/cdn'` and export `resolveCdnBase()` for testing.

## Test plan

- [x] `npm test -- tests/cdn.test.ts`
- [x] Manual: dev server + curl `/cdn/themes/.../manifest.xml` returns XML
- [x] Manual: Playwright — no "WMR 渲染失败" on launcher after `localStorage.clear()` + reload