### PR TITLE
fix: restore working star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,11 +469,11 @@ If MobileGym helps your research, please cite us:
 ```
 ## Star History
 
-<a href="https://www.star-history.com/?repos=Purewhiter%2Fmobilegym&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#Purewhiter/mobilegym&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Purewhiter/mobilegym&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Purewhiter/mobilegym&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Purewhiter/mobilegym&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Purewhiter/mobilegym&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Purewhiter/mobilegym&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Purewhiter/mobilegym&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -472,7 +472,7 @@ MobileGym 采用**双 license** 设计 —— 再分发前请同时阅读两份�
 
 ## Star 增长曲线
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Purewhiter/mobilegym&type=Date)](https://star-history.com/#Purewhiter/mobilegym&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Purewhiter/mobilegym&type=Date)](https://star-history.dera.page/#Purewhiter/mobilegym&Date)
 
 <br/>
 


### PR DESCRIPTION
The current star history charts in the English and Chinese READMEs are broken. Update their chart links so the project star history is displayed again while preserving the existing repository and display settings.